### PR TITLE
Add travis support for embARC OSP applications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+language: python
+
+sudo: required
+dist: trusty
+
+python:
+  - "3.6"
+
+before_install:
+  - bash .travis/before_install.sh
+  # setup git
+  - git config --global user.name "${U_NAME}"
+  - git config --global user.email "${U_EMAIL}"
+
+script:
+  - bash .travis/script.sh
+
+matrix:
+  include:
+    - env: TOOLCHAIN="gnu" BOARD="emsk" BD_VER="11" CUR_CORE="arcem6"
+      os: linux
+      compiler: gcc
+    - env: TOOLCHAIN="gnu" BOARD="emsk" BD_VER="22" CUR_CORE="arcem7d"
+      os: linux
+      compiler: gcc
+    - env: TOOLCHAIN="gnu" BOARD="emsk" BD_VER="22" CUR_CORE="arcem11d"
+      os: linux
+      compiler: gcc
+    - env: TOOLCHAIN="gnu" BOARD="emsk" BD_VER="23" CUR_CORE="arcem7d"
+      os: linux
+      compiler: gcc
+    - env: TOOLCHAIN="gnu" BOARD="emsk" BD_VER="23" CUR_CORE="arcem11d"
+      os: linux
+      compiler: gcc

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -1,0 +1,26 @@
+die() {
+
+	echo " *** ERROR: " $*
+
+	exit 1 
+
+}
+set -x 
+
+cd /tmp || die
+[ $TRAVIS_OS_NAME != linux ] || {
+
+    sudo apt-get update || die 
+    sudo apt-get install lib32z1 || die
+    sudo apt-get install dos2unix || die
+    wget https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/releases/download/arc-2017.09-release/arc_gnu_2017.09_prebuilt_elf32_le_linux_install.tar.gz || die
+    tar xzf arc_gnu_2017.09_prebuilt_elf32_le_linux_install.tar.gz || die
+    export PATH=/tmp/arc_gnu_2017.09_prebuilt_elf32_le_linux_install/bin:$PATH || die 
+    arc-elf32-gcc --version || die
+    sudo apt-get install doxygen || die
+    sudo pip install --upgrade pip || die
+    sudo pip install git+https://github.com/sphinx-doc/sphinx || die
+    sudo pip install breathe || die 
+    sudo pip install recommonmark || die 
+    sudo pip install sphinx_rtd_theme || die 
+}

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -17,10 +17,4 @@ cd /tmp || die
     tar xzf arc_gnu_2017.09_prebuilt_elf32_le_linux_install.tar.gz || die
     export PATH=/tmp/arc_gnu_2017.09_prebuilt_elf32_le_linux_install/bin:$PATH || die 
     arc-elf32-gcc --version || die
-    sudo apt-get install doxygen || die
-    sudo pip install --upgrade pip || die
-    sudo pip install git+https://github.com/sphinx-doc/sphinx || die
-    sudo pip install breathe || die 
-    sudo pip install recommonmark || die 
-    sudo pip install sphinx_rtd_theme || die 
 }

--- a/.travis/build.py
+++ b/.travis/build.py
@@ -1,0 +1,57 @@
+import json
+import os
+import sys
+
+folder = ".travis"
+make_path = dict()
+makefile = 'makefile'
+
+def get_makefile(path): # to find the makefile in the embarc_applications
+	path = os.path.abspath(path)
+	for root, dirs, files in os.walk(path):
+		dirs[:] = [d for d in dirs  if not d.startswith('.')]
+		for f in files:
+			if f == makefile:
+				key = os.path.basename(root)+'_'+os.path.basename(os.path.dirname(root))
+				make_path[key] = root
+
+def embarc_makefile(paths): # to confirm the file is a embarc makefile
+	for (k,v) in paths.items():
+		with open(os.path.join(v,"makefile")) as f:
+			embarc_root = False
+			appl = False
+			lines = f.read().splitlines()
+			for line in lines:
+				if "EMBARC_ROOT" in line:
+					embarc_root = True
+				if "APPL" in line:
+					appl = True
+			if not (embarc_root and appl):
+				paths.pop(k)
+
+if __name__ == '__main__':
+	result = {}
+	cwd_path = os.getcwd() # /travis
+	applications_path = os.path.dirname(cwd_path) # # /embarc_application
+	osp_application = applications_path+"/embarc_osp/embarc_applications"# /embarc_osp/application
+
+	os.chdir(os.path.join(applications_path,"embarc_osp"))
+	get_makefile(osp_application)
+	embarc_makefile(make_path)
+	for (k,v) in make_path.items():
+		result[k] = 0
+		print("application[%s]=" %k,v)
+		pathin = v.replace("\\", "/")
+		os.chdir(pathin)
+		os.system("make "+sys.argv[1]+" clean") 
+
+		if os.system("make "+sys.argv[1]+" -k") != 0:
+
+			result[k] = 1
+		pathout = cwd_path 
+		os.chdir(pathout)
+	print(result)
+	for (k,v) in result.items():
+		if v == 1:
+			sys.exit(1)
+	sys.exit(0)

--- a/.travis/build.py
+++ b/.travis/build.py
@@ -43,6 +43,8 @@ if __name__ == '__main__':
 		print("application[%s]=" %k,v)
 		pathin = v.replace("\\", "/")
 		os.chdir(pathin)
+		print("make configuration: ",sys.argv[1])
+		print("start compile")
 		os.system("make "+sys.argv[1]+" clean") 
 
 		if os.system("make "+sys.argv[1]+" -k") != 0:
@@ -50,8 +52,10 @@ if __name__ == '__main__':
 			result[k] = 1
 		pathout = cwd_path 
 		os.chdir(pathout)
+	print("Compilation result")
 	print(result)
 	for (k,v) in result.items():
 		if v == 1:
+			print("build failed")
 			sys.exit(1)
 	sys.exit(0)

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -1,0 +1,45 @@
+embARC_OSP_REPO="https://github.com/foss-for-synopsys-dwc-arc-processors/embarc_osp.git"
+
+die() {
+    echo " *** ERROR: " $*
+    exit 1
+
+}
+set -x
+
+[ $TRAVIS_OS_NAME != linux ] || {
+
+    export PATH=/tmp/arc_gnu_2017.09_prebuilt_elf32_le_linux_install/bin:$PATH || die
+    git checkout -- . || die
+    cd ../ || die
+    tar -czvf application.tar.gz embarc_applications || die
+    cd embarc_applications || die
+    git clone ${embARC_OSP_REPO} embarc_osp
+    cd embarc_osp || die
+    tar -zxvf ../../application.tar.gz || die
+    bash apply_embARC_patch.sh || die
+    cd ../ || die
+    cd .travis || die
+    [ $TOOLCHAIN != gnu -o $BOARD != emsk -o $BD_VER != 11 -o $CUR_CORE != arcem6 ] || {
+
+        python3 build.py "TOOLCHAIN=${TOOLCHAIN} BOARD=${BOARD} BD_VER=${BD_VER} CUR_CORE=${CUR_CORE}" || die
+    }
+    [ $TOOLCHAIN != gnu -o $BOARD != emsk -o $BD_VER != 22 -o $CUR_CORE != arcem7d ] || {
+
+        python3 build.py "TOOLCHAIN=${TOOLCHAIN} BOARD=${BOARD} BD_VER=${BD_VER} CUR_CORE=${CUR_CORE}" || die
+    }
+
+    [ $TOOLCHAIN != gnu -o $BOARD != emsk -o $BD_VER != 22 -o $CUR_CORE != arcem11d ] || {
+
+        python3 build.py "TOOLCHAIN=${TOOLCHAIN} BOARD=${BOARD} BD_VER=${BD_VER} CUR_CORE=${CUR_CORE}" || die
+    }
+    [ $TOOLCHAIN != gnu -o $BOARD != emsk -o $BD_VER != 23 -o $CUR_CORE != arcem7d ] || {
+
+        python3 build.py "TOOLCHAIN=${TOOLCHAIN} BOARD=${BOARD} BD_VER=${BD_VER} CUR_CORE=${CUR_CORE}" || die
+    }
+    [ $TOOLCHAIN != gnu -o $BOARD != emsk -o $BD_VER != 23 -o $CUR_CORE != arcem11d ] || {
+
+        python3 build.py "TOOLCHAIN=${TOOLCHAIN} BOARD=${BOARD} BD_VER=${BD_VER} CUR_CORE=${CUR_CORE}" || die
+    }
+
+}

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -1,5 +1,3 @@
-embARC_OSP_REPO="https://github.com/foss-for-synopsys-dwc-arc-processors/embarc_osp.git"
-
 die() {
     echo " *** ERROR: " $*
     exit 1
@@ -11,12 +9,13 @@ set -x
 
     export PATH=/tmp/arc_gnu_2017.09_prebuilt_elf32_le_linux_install/bin:$PATH || die
     git checkout -- . || die
-    cd ../ || die
-    tar -czvf application.tar.gz embarc_applications || die
-    cd embarc_applications || die
+    git archive --format zip -o applications.zip --prefix embarc_applications/ HEAD || die
+    [ $embARC_OSP_REPO ] || {
+        embARC_OSP_REPO="https://github.com/foss-for-synopsys-dwc-arc-processors/embarc_osp.git"
+    }
     git clone ${embARC_OSP_REPO} embarc_osp
     cd embarc_osp || die
-    tar -zxvf ../../application.tar.gz || die
+    unzip ../applications.zip || die
     bash apply_embARC_patch.sh || die
     cd ../ || die
     cd .travis || die

--- a/ibaby_smarthome_multinode/src/lamp_node/function/lwm2m/lwm2m.c
+++ b/ibaby_smarthome_multinode/src/lamp_node/function/lwm2m/lwm2m.c
@@ -54,7 +54,7 @@
 #include <netdb.h>
 #include <sys/stat.h>
 #include <errno.h>
-#include "lwip_pmwifi.h"
+#include "lwip_wifi.h"
 
 /* custom HAL */
 #include "common.h"
@@ -110,7 +110,7 @@ extern int32_t lwm2m_client_start(void)
 	task_lwm2m_client_handle = 0;
 
 	/* check to see if wifi works */
-	if (!lwip_pmwifi_isup()) {
+	if (!lwip_wifi_isup()) {
 		EMBARC_PRINTF("Error: Wifi is not ready for lwM2M client.\r\n");
 		goto error_exit;
 	}

--- a/ibaby_smarthome_multinode/src/wearable_node/function/lwm2m/lwm2m.c
+++ b/ibaby_smarthome_multinode/src/wearable_node/function/lwm2m/lwm2m.c
@@ -54,7 +54,7 @@
 #include <netdb.h>
 #include <sys/stat.h>
 #include <errno.h>
-#include "lwip_pmwifi.h"
+#include "lwip_wifi.h"
 
 /* custom HAL */
 #include "common.h"
@@ -110,7 +110,7 @@ extern int32_t lwm2m_client_start(void)
 	task_lwm2m_client_handle = 0;
 
 	/* check to see if wifi works */
-	if (!lwip_pmwifi_isup()) {
+	if (!lwip_wifi_isup()) {
 		EMBARC_PRINTF("Error: Wifi is not ready for lwM2M client.\r\n");
 		goto error_exit;
 	}


### PR DESCRIPTION
# Summary
- Can't compile the application named "ibaby_smarthome_multinode", because the API about wifi has changed. I modified two files named "lwm2m.c"  in this application.
- Add  the Travis CI app to this repository . The file .travis.yml file can trigger a Travis CI build, and the .travis folder contains 3 configuration files.


# User Manual
Every time when you commit or push a Travis CI build will be triggered.